### PR TITLE
Fixup 'latest' handling and how things are uploaded to S3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,16 +3,14 @@
 PROJECT_NAME ?= docsdockercom
 DOCKER_COMPOSE := docker-compose -p $(PROJECT_NAME)
 DOCKER_IP = $(shell python -c "import urlparse ; print urlparse.urlparse('$(DOCKER_HOST)').hostname or ''")
-HUGO_BASE_URL = $(shell test -z "$(DOCKER_IP)" && echo localhost || echo "$(DOCKER_IP)")
-HUGO_BIND_IP = 0.0.0.0
-DATA_CONTAINER_CMD = $(DOCKER_COMPOSE) ps -q data | head -n 1
-RELEASE_LATEST ?=
-
-ifndef RELEASE_LATEST
-	DOCS_VERSION = $(shell cat VERSION | head -n1 | awk '{print $$1}')
+ifndef HUGO_BASE_URL
+	HUGO_BASE_URL_AUTO = 1
+	HUGO_BASE_URL = $(shell test -z "$(DOCKER_IP)" && echo localhost || echo "$(DOCKER_IP)")
 else
-	DOCS_VERSION =
+	HUGO_BASE_URL ?= $(HUGO_BASE_URL)
 endif
+DATA_CONTAINER_CMD = $(DOCKER_COMPOSE) ps -q data | head -n 1
+DOCS_VERSION = $(shell cat VERSION | head -n1 | awk '{print $$1}')
 
 default: build-images build
 
@@ -30,17 +28,15 @@ clean:
 	$(DOCKER_COMPOSE) rm -fv ; \
 	docker rmi $$( docker images | grep -E '^$(PROJECT_NAME)_' | awk '{print $$1}' ) 2>/dev/null ||:
 
-clean-bucket:
-	RM_OLDER_THAN="$(RM_OLDER_THAN)" $(DOCKER_COMPOSE) run --rm cleanup
-
 serve: fetch
-	HUGO_BIND_IP=$(HUGO_BIND_IP) HUGO_BASE_URL=$(HUGO_BASE_URL) $(DOCKER_COMPOSE) up serve
+	HUGO_BASE_URL=$(DOCKER_IP) $(DOCKER_COMPOSE) up serve
 
 build: fetch
-	DOCS_VERSION=$(DOCS_VERSION) $(DOCKER_COMPOSE) up build
+	HUGO_BASE_URL=$(HUGO_BASE_URL) DOCS_VERSION=$(DOCS_VERSION) $(DOCKER_COMPOSE) up build
 
 release: build
-	CLEAN=$(DOCS_VERSION) $(DOCKER_COMPOSE) up upload
+	[ -n "$(HUGO_BASE_URL_AUTO)" ] && echo "Set HUGO_BASE_URL to release" && exit 1 ; \
+	HUGO_BASE_URL=$(HUGO_BASE_URL) DOCS_VERSION=$(DOCS_VERSION) $(DOCKER_COMPOSE) up upload
 
 export: build
 	docker cp $$($(DATA_CONTAINER_CMD)):/public - | gzip > docs-docker-com.tar.gz

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,10 @@ fetch:
 
 build:
     build: .
-    command: /bin/bash -ec "hugo -d /public/$DOCS_VERSION"
+    command: |
+      /bin/bash -ec ' \
+      hugo -d /public/$DOCS_VERSION
+      '
     working_dir: /docs
     volumes_from:
         - data
@@ -32,64 +35,28 @@ upload:
     working_dir: /public
     command: |
         /bin/bash -c ' \
-        if [ -n "$CLEAN" ] ; then
-          aws s3 rm --recursive s3://$AWS_S3_BUCKET/$CLEAN
-        fi
-        aws s3 sync --acl=public-read . s3://$AWS_S3_BUCKET
+        sleep 1
+        [ -z "$DOCS_VERSION" ]          && echo "DOCS_VERSION is not set" >&2          && exit 1
+        [ -z "$AWS_ACCESS_KEY_ID" ]     && echo "AWS_ACCESS_KEY_ID is not set" >&2     && exit 1
+        [ -z "$AWS_SECRET_ACCESS_KEY" ] && echo "AWS_SECRET_ACCESS_KEY is not set" >&2 && exit 1
+        [ -z "$AWS_S3_BUCKET" ]         && echo "AWS_S3_BUCKET is not set" >&2         && exit 1
+
+        aws s3 sync --exact-timestamps --delete --acl=public-read "./$DOCS_VERSION" "s3://$AWS_S3_BUCKET/$DOCS_VERSION"
         '
     volumes_from:
         - data
     environment:
-        - CLEAN
+        - DOCS_VERSION
         - AWS_ACCESS_KEY_ID
         - AWS_SECRET_ACCESS_KEY
         - AWS_S3_BUCKET
 
-cleanup:
-  build: .
-  command: |
-    /bin/bash -c ' \
-    if [[ "$AWS_S3_BUCKET" =~ "/" ]] ; then
-      BUCKET_PATH=$( echo "$AWS_S3_BUCKET" | sed "s/[^\/]*\///" )
-      BUCKET_PATH+="/"
-      AWS_S3_BUCKET=$( echo "$AWS_S3_BUCKET" | sed "s/\/.*//")
-    else
-      BUCKET_PATH=
-    fi
-
-    [ -z "$RM_OLDER_THAN" ] && exit 1
-    CUTOFF_UNIX_TS=$( date --date "$RM_OLDER_THAN" '+%s' )
-    aws s3 ls --recursive s3://$AWS_S3_BUCKET/$BUCKET_PATH | while read -a LINE ; do
-      DATE="${LINE[0]}"
-      TIME="${LINE[1]}"
-      SIZE="${LINE[2]}"
-      NAME="${LINE[*]:3}"
-
-      VERSION_REGEX="^${BUCKET_PATH}v[0-9]+\.[0-9]+/"
-      UNIX_TS=$( date --date "$DATE $TIME" "+%s" )
-
-      if [[ "$NAME" =~ $VERSION_REGEX ]] || [[ "$CUTOFF_UNIX_TS" -le "$UNIX_TS" ]] ; then
-        echo "Keeping $NAME"
-        continue
-      fi
-
-      echo "Creating redirect for $NAME"
-      aws s3 cp "s3://$AWS_S3_BUCKET/$NAME" "s3://$AWS_S3_BUCKET/$NAME" --website-redirect="/${BUCKET_PATH}index.html" --acl=public-read > /dev/null
-    done
-    '
-  environment:
-    - RM_OLDER_THAN
-    - AWS_ACCESS_KEY_ID
-    - AWS_SECRET_ACCESS_KEY
-    - AWS_S3_BUCKET
-
 serve:
     build: .
     working_dir: /docs
-    command: /bin/bash -c "hugo server -d /public --port=8000 --baseUrl=$HUGO_BASE_URL --bind=$HUGO_BIND_IP"
+    command: /bin/bash -c "hugo server -d /public --port=8000 --baseUrl=$HUGO_BASE_URL --bind=0.0.0.0"
     environment:
         - HUGO_BASE_URL
-        - HUGO_BIND_IP
     ports:
         - "8000:8000"
     volumes_from:
@@ -101,7 +68,7 @@ test:
     command: |
         /bin/bash -c " \
         URL=http://$HUGO_BASE_URL:8000
-        hugo server -d /public --port=8000 --baseUrl=$HUGO_BASE_URL --bind=$HUGO_BIND_IP &
+        hugo server -d /public --port=8000 --baseUrl=$HUGO_BASE_URL --bind=$HUGO_BIND_IP & \
         until curl --fail --silent $URL ; do \
           sleep 1 ; \
         done


### PR DESCRIPTION
TL;DR: This should take care of the open P1 issues: #28, #29, #34.

* `LATEST=1` for #29: Using this environment variable will result in a copy of the content in two separate directories: one named after the `VERSION` and one named 'latest'. Both copies are synced to S3 (version first, then latest).
* `aws s3 sync --delete` for #29: This is just the addition of a flag that was not provided previously. See the AWS CLI docs here for more info: http://docs.aws.amazon.com/cli/latest/reference/s3/sync.html
* `HUGO_BASE_URL=...` for #34: In order to run `make release`, the HUGO_BASE_URL environment variable **must** be set. The make process will exit with a failure if it is not set.

Putting it all together, you can do a new release to docs.docker.com as follows:

```bash
HUGO_BASE_URL="docs.docker.com" LATEST=1 make release
```

You can leave out `LATEST=1` if you need to (for example) update the v1.5 docs.
***

Note that if we are able to move ahead and remove the 'root' copy of the documentation, we will need to put a file at /index.html which redirects to /latest/index.html

***
@moxiegirl 