### PR TITLE
Updating with the latest used in publishing

### DIFF
--- a/all-projects.yml
+++ b/all-projects.yml
@@ -32,7 +32,7 @@ projects:
       
     - name: registry
       repo_name: distribution   
-      ref: master
+      ref: registr/2.1
       path: docs/    
       
     - name: kitematic


### PR DESCRIPTION
Publishes after 1.8 should use the registry/2.1 ref

Signed-off-by: Mary Anthony <mary@docker.com>