### PR TITLE
Use git tag for image tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,9 @@
 .PHONY: all default build-images fetch clean clean-bucket test serve build release export shell
 
 PROJECT_NAME ?= docsdockercom
-DOCKER_COMPOSE := docker-compose -p $(PROJECT_NAME)
-DOCKER_IMAGE := docsdockercom:latest
+DOCKER_COMPOSE := docker-compose-1.5.0rc1 -p $(PROJECT_NAME)
+export IMAGE_TAG ?= $(shell git rev-parse --short HEAD)
+DOCKER_IMAGE := docsdockercom:$(IMAGE_TAG)
 DOCKER_IP = $(shell python -c "import urlparse ; print urlparse.urlparse('$(DOCKER_HOST)').hostname or ''")
 HUGO_BASE_URL = $(shell test -z "$(DOCKER_IP)" && echo localhost || echo "$(DOCKER_IP)")
 HUGO_BIND_IP = 0.0.0.0
@@ -21,7 +22,7 @@ build-images:
 	docker build -t $(DOCKER_IMAGE) .
 
 fetch:
-	$(DOCKER_COMPOSE) up fetch
+	$(DOCKER_COMPOSE) run fetch
 
 clean:
 	$(DOCKER_COMPOSE) rm -fv ; \

--- a/cleanup.sh
+++ b/cleanup.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+set -e
+
+if [[ "$AWS_S3_BUCKET" =~ "/" ]] ; then
+    BUCKET_PATH=$( echo "$AWS_S3_BUCKET" | sed "s/[^\/]*\///" )
+    BUCKET_PATH+="/"
+    AWS_S3_BUCKET=$( echo "$AWS_S3_BUCKET" | sed "s/\/.*//")
+else
+    BUCKET_PATH=
+fi
+
+[ -z "$RM_OLDER_THAN" ] && exit 1
+CUTOFF_UNIX_TS=$( date --date "$RM_OLDER_THAN" '+%s' )
+aws s3 ls --recursive s3://$AWS_S3_BUCKET/$BUCKET_PATH | while read -a LINE ; do
+    DATE="${LINE[0]}"
+    TIME="${LINE[1]}"
+    SIZE="${LINE[2]}"
+    NAME="${LINE[*]:3}"
+
+    VERSION_REGEX="^${BUCKET_PATH}v[0-9]+\.[0-9]+/"
+    UNIX_TS=$( date --date "$DATE $TIME" "+%s" )
+
+    if [[ "$NAME" =~ $VERSION_REGEX ]] || [[ "$CUTOFF_UNIX_TS" -le "$UNIX_TS" ]] ; then
+        echo "Keeping $NAME"
+        continue
+    fi
+
+    echo "Creating redirect for $NAME"
+    aws s3 cp "s3://$AWS_S3_BUCKET/$NAME" "s3://$AWS_S3_BUCKET/$NAME" --website-redirect="/${BUCKET_PATH}index.html" --acl=public-read > /dev/null
+done
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ data:
         - /public
 
 fetch:
-    image: docsdockercom:latest
+    image: docsdockercom:${IMAGE_TAG}
     command: |
         /bin/bash -ec " \
         python fetch_content.py /docs all-projects.yml
@@ -19,8 +19,8 @@ fetch:
         - GITHUB_TOKEN
 
 build:
-    image: docsdockercom:latest
-    command: /bin/bash -ec "hugo -d /public/$DOCS_VERSION"
+    image: docsdockercom:${IMAGE_TAG}
+    command: /bin/bash -ec "hugo -d /public/$$DOCS_VERSION"
     working_dir: /docs
     volumes_from:
         - data
@@ -28,15 +28,9 @@ build:
         - DOCS_VERSION
 
 upload:
-    image: docsdockercom:latest
+    image: docsdockercom:${IMAGE_TAG}
     working_dir: /public
-    command: |
-        /bin/bash -c ' \
-        if [ -n "$CLEAN" ] ; then
-          aws s3 rm --recursive s3://$AWS_S3_BUCKET/$CLEAN
-        fi
-        aws s3 sync --acl=public-read . s3://$AWS_S3_BUCKET
-        '
+    command: /src/upload.sh
     volumes_from:
         - data
     environment:
@@ -46,37 +40,8 @@ upload:
         - AWS_S3_BUCKET
 
 cleanup:
-    image: docsdockercom:latest
-    command: |
-        /bin/bash -c ' \
-        if [[ "$AWS_S3_BUCKET" =~ "/" ]] ; then
-            BUCKET_PATH=$( echo "$AWS_S3_BUCKET" | sed "s/[^\/]*\///" )
-            BUCKET_PATH+="/"
-            AWS_S3_BUCKET=$( echo "$AWS_S3_BUCKET" | sed "s/\/.*//")
-        else
-            BUCKET_PATH=
-        fi
-
-        [ -z "$RM_OLDER_THAN" ] && exit 1
-        CUTOFF_UNIX_TS=$( date --date "$RM_OLDER_THAN" '+%s' )
-        aws s3 ls --recursive s3://$AWS_S3_BUCKET/$BUCKET_PATH | while read -a LINE ; do
-            DATE="${LINE[0]}"
-            TIME="${LINE[1]}"
-            SIZE="${LINE[2]}"
-            NAME="${LINE[*]:3}"
-
-            VERSION_REGEX="^${BUCKET_PATH}v[0-9]+\.[0-9]+/"
-            UNIX_TS=$( date --date "$DATE $TIME" "+%s" )
-
-            if [[ "$NAME" =~ $VERSION_REGEX ]] || [[ "$CUTOFF_UNIX_TS" -le "$UNIX_TS" ]] ; then
-                echo "Keeping $NAME"
-                continue
-            fi
-
-            echo "Creating redirect for $NAME"
-            aws s3 cp "s3://$AWS_S3_BUCKET/$NAME" "s3://$AWS_S3_BUCKET/$NAME" --website-redirect="/${BUCKET_PATH}index.html" --acl=public-read > /dev/null
-        done
-        '
+    image: docsdockercom:${IMAGE_TAG}
+    command: /src/cleanup.sh
     environment:
         - RM_OLDER_THAN
         - AWS_ACCESS_KEY_ID
@@ -84,9 +49,9 @@ cleanup:
         - AWS_S3_BUCKET
 
 serve:
-    image: docsdockercom:latest
+    image: docsdockercom:${IMAGE_TAG}
     working_dir: /docs
-    command: /bin/bash -c "hugo server -d /public --port=8000 --baseUrl=$HUGO_BASE_URL --bind=$HUGO_BIND_IP"
+    command: /bin/bash -c "hugo server -d /public --port=8000 --baseUrl=$$HUGO_BASE_URL --bind=$$HUGO_BIND_IP"
     environment:
         - HUGO_BASE_URL
         - HUGO_BIND_IP
@@ -96,17 +61,9 @@ serve:
         - data
 
 test:
-    image: docsdockercom:latest
+    image: docsdockercom:${IMAGE_TAG}
     working_dir: /docs
-    command: |
-        /bin/bash -c " \
-        URL=http://$HUGO_BASE_URL:8000
-        hugo server -d /public --port=8000 --baseUrl=$HUGO_BASE_URL --bind=$HUGO_BIND_IP &
-        until curl --fail --silent $URL ; do \
-          sleep 1 ; \
-        done
-        exec python /src/docvalidate.py $URL
-        "
+    command: /src/test.sh
     environment:
         - HUGO_BASE_URL
         - HUGO_BIND_IP

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,12 +20,10 @@ fetch:
 
 build:
     image: docsdockercom:${IMAGE_TAG}
-    command: /bin/bash -ec "hugo -d /public/$$DOCS_VERSION"
+    command: "hugo -d /public/$DOCS_VERSION"
     working_dir: /docs
     volumes_from:
         - data
-    environment:
-        - DOCS_VERSION
 
 upload:
     image: docsdockercom:${IMAGE_TAG}
@@ -51,10 +49,7 @@ cleanup:
 serve:
     image: docsdockercom:${IMAGE_TAG}
     working_dir: /docs
-    command: /bin/bash -c "hugo server -d /public --port=8000 --baseUrl=$$HUGO_BASE_URL --bind=$$HUGO_BIND_IP"
-    environment:
-        - HUGO_BASE_URL
-        - HUGO_BIND_IP
+    command: "hugo server -d /public --port=8000 --baseUrl=$HUGO_BASE_URL --bind=0.0.0.0"
     ports:
         - "8000:8000"
     volumes_from:
@@ -63,11 +58,6 @@ serve:
 test:
     image: docsdockercom:${IMAGE_TAG}
     working_dir: /docs
-    command: /src/test.sh
-    environment:
-        - HUGO_BASE_URL
-        - HUGO_BIND_IP
-    ports:
-        - "8000:8000"
-    volumes_from:
-        - data
+    command: 'python /src/docvalidate.py http://serve:8000'
+    links:
+        - serve

--- a/fetch_content.py
+++ b/fetch_content.py
@@ -71,10 +71,12 @@ def gather_git_info(org, repo_name, ref):
         ref=ref
     )
 
-    commit_info = requests.get(
+    response = requests.get(
         'https://api.github.com/repos/{org}/{repo_name}/commits/{ref}'.format(**info),
         auth=(os.environ['GITHUB_USERNAME'], os.environ['GITHUB_TOKEN']),
-    ).json()
+    )
+    response.raise_for_status()
+    commit_info = response.json()
 
     info['sha'] = commit_info['sha']
     info['archive_url'] = 'https://github.com/{org}/{repo_name}/archive/{sha}.tar.gz'.format(**info)

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+
+URL=http://$HUGO_BASE_URL:8000
+hugo server -d /public --port=8000 --baseUrl=$HUGO_BASE_URL --bind=$HUGO_BIND_IP &
+until curl --fail --silent $URL ; do \
+  sleep 1 ; \
+done
+exec python /src/docvalidate.py $URL

--- a/test.sh
+++ b/test.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-set -e
-
-URL=http://$HUGO_BASE_URL:8000
-hugo server -d /public --port=8000 --baseUrl=$HUGO_BASE_URL --bind=$HUGO_BIND_IP &
-until curl --fail --silent $URL ; do \
-  sleep 1 ; \
-done
-exec python /src/docvalidate.py $URL

--- a/upload.sh
+++ b/upload.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -e
+
+if [ -n "$CLEAN" ] ; then
+  aws s3 rm --recursive s3://$AWS_S3_BUCKET/$CLEAN
+fi
+aws s3 sync --acl=public-read . s3://$AWS_S3_BUCKET


### PR DESCRIPTION
Following up on #58

**note**: this requires docker-compose 1.5.0 (currently rc1) to support a variable name for the image tag

compose 1.5.0 also added variable interpolation in the docker-compose.yml, so some of the compose file had to change to support it (variables that you don't want to interpolate in the config need to be escaped with `$$`).  Instead of escaping them I moved out some of the larger scripts into their own files.

I exported some variables from the Makefile so they don't have to be passed directly to the compose command. This makes it possible to run other services without calling the exact make target that sets the variables (ex: the `serve` service would not run unless you called the `serve` target, now it will as long as you call any target in the makefile, because the variables are expected).

Finally I added a `test` target to run the test service.  Instead of running two processes in the container, I make use of compose to link the test container to the `serve` service.  I'm not sure if this test service is being used, but I'm pretty sure it doesn't actually do what you want.  The regex here: https://github.com/docker/docs.docker.com/blob/master/docvalidate.py#L48 doesn't work for urls that start with `./` which is most of them (I think).

