### PR TITLE
Add linkchecker for running automated checking of links within docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /public
 *.pyc
+target/

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
-.PHONY: all default build-images fetch clean clean-bucket test serve build release export shell
+.PHONY: all default build-images fetch clean clean-bucket test serve build release export shell linkchecker
 
 PROJECT_NAME ?= docsdockercom
-DOCKER_COMPOSE := docker-compose -p $(PROJECT_NAME)
+DOCKER_COMPOSE ?= docker-compose -p $(PROJECT_NAME)
 DOCKER_IMAGE := docsdockercom:latest
 DOCKER_IP = $(shell python -c "import urlparse ; print urlparse.urlparse('$(DOCKER_HOST)').hostname or ''")
 HUGO_BASE_URL = $(shell test -z "$(DOCKER_IP)" && echo localhost || echo "$(DOCKER_IP)")
@@ -41,6 +41,12 @@ release: build
 
 export: build
 	docker cp $$($(DATA_CONTAINER_CMD)):/public - | gzip > docs-docker-com.tar.gz
+
+linkchecker:
+	mkdir -p target
+	$(DOCKER_COMPOSE) up -d serve
+	$(DOCKER_COMPOSE) run --rm linkchecker
+	$(DOCKER_COMPOSE) stop
 
 shell: build
 	$(DOCKER_COMPOSE) run --rm build /bin/bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -114,3 +114,11 @@ test:
         - "8000:8000"
     volumes_from:
         - data
+
+linkchecker:
+    build: ./linkchecker
+    command: '-F csv/utf_8//target/output.csv http://docs:8000/'
+    volumes:
+        - ./target:/target
+    links:
+        - serve:docs

--- a/linkchecker/Dockerfile
+++ b/linkchecker/Dockerfile
@@ -1,0 +1,19 @@
+
+FROM    debian:jessie
+
+RUN     apt-get update && \
+        DEBIAN_FRONTEND=noninteractive apt-get install -y \
+            locales \
+            linkchecker \
+            patch
+
+RUN     locale-gen en_US.UTF-8
+ENV     LANG en_US.UTF-8
+
+# Patch to fix ssl bug, see https://github.com/wummel/linkchecker/issues/566
+COPY    . /src
+RUN     patch /usr/lib/python2.7/dist-packages/linkcheck/httputil.py /src/httputil.py.patch
+
+RUN     adduser checker --disabled-password
+USER    checker
+ENTRYPOINT ["linkchecker"]

--- a/linkchecker/httputil.py.patch
+++ b/linkchecker/httputil.py.patch
@@ -1,0 +1,17 @@
+@@ -32,14 +32,14 @@
+     """Parse a x509 pyopenssl object to a dictionary with keys
+     subject, subjectAltName and optional notAfter.
+     """
+-    from requests.packages.urllib3.contrib.pyopenssl import get_subj_alt_name
++    import requests.packages.urllib3.contrib.pyopenssl as pyopenssl
+     res = {
+             'subject': (
+                 (('commonName', x509.get_subject().CN),),
+             ),
+             'subjectAltName': [
+                 ('DNS', value)
+-                for value in get_subj_alt_name(x509)
++                for value in pyopenssl.get_subj_alt_name(x509)
+             ]
+     }
+     notAfter = x509.get_notAfter()


### PR DESCRIPTION
This adds a dockerfile and makefile target for running http://wummel.github.io/linkchecker/

It starts a `serve` container, and a `linkchecker` container that links to `serve`.

It then runs over the docs and finds broken links.  The output is currently configured as CSV, but there are other options: https://wummel.github.io/linkchecker/man1/linkchecker.1.html

I ran it and it reports:

165181 links in 637 URLs checked. 0 warnings found. 151 errors found
in (3 minutes, 59 seconds)
