### PR TITLE
Fix make clean, which should rmi the image created by build-images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,8 +24,7 @@ fetch:
 	$(DOCKER_COMPOSE) run --rm fetch
 
 clean:
-	$(DOCKER_COMPOSE) rm -fv ; \
-	docker rmi $$( docker images | grep -E '^$(PROJECT_NAME)_' | awk '{print $$1}' ) 2>/dev/null ||:
+	docker rmi $(DOCKER_IMAGE)
 
 clean-bucket:
 	RM_OLDER_THAN="$(RM_OLDER_THAN)" $(DOCKER_COMPOSE) run --rm cleanup


### PR DESCRIPTION
Oops, I broke this in #58

Now that we're building a single image in the Makefile using docker, we can clean it up with a single docker command as well.