### PR TITLE
Use branch name for build image tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 PROJECT_NAME ?= docsdockercom
 DOCKER_COMPOSE := docker-compose-1.5.0rc1 -p $(PROJECT_NAME)
-export IMAGE_TAG ?= $(shell git rev-parse --short HEAD)
+export IMAGE_TAG ?= $(shell git rev-parse --abbrev-ref HEAD)
 DOCKER_IMAGE := docsdockercom:$(IMAGE_TAG)
 DOCKER_IP = $(shell python -c "import urlparse ; print urlparse.urlparse('$(DOCKER_HOST)').hostname or ''")
 export HUGO_BASE_URL = $(shell test -z "$(DOCKER_IP)" && echo localhost || echo "$(DOCKER_IP)")


### PR DESCRIPTION
Using the git sha by default makes it hard to cleanup images. Instead let's use `latest` by default.

If you need to build a different branch, you can use 

```
IMAGE_TAG=<something unique> make build-images
```

Does that work?  Should we default to branch name instead?