### PR TITLE
Use host volumes and less verbose fetch logging

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+docs
+public
+target
+.git

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /public
+/docs
 *.pyc

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,8 +2,8 @@ data:
     image: busybox
     command: "true"
     volumes:
-        - /docs
-        - /public
+        - ./docs:/docs
+        - ./public:/public
 
 fetch:
     image: docsdockercom:${IMAGE_TAG}
@@ -12,6 +12,8 @@ fetch:
         python fetch_content.py /docs all-projects.yml
         ./touch-up.sh /docs
         "
+    volumes:
+        - '.:/src'
     volumes_from:
         - data
     environment:
@@ -49,7 +51,7 @@ cleanup:
 serve:
     image: docsdockercom:${IMAGE_TAG}
     working_dir: /docs
-    command: "hugo server -d /public --port=8000 --baseUrl=$HUGO_BASE_URL --bind=0.0.0.0"
+    command: "hugo server -d /public --port=8000 --baseUrl=$HUGO_BASE_URL --bind=0.0.0.0 --watch"
     ports:
         - "8000:8000"
     volumes_from:

--- a/fetch_content.py
+++ b/fetch_content.py
@@ -91,6 +91,7 @@ def fetch_project(destination, org, repo_name, name, ref, path, ignores=None, ta
     git_info = gather_git_info(org, repo_name, ref)
     archive_url = git_info.pop('archive_url')
 
+    print "Fetching project %s" % archive_url
     resp = requests.get(
         archive_url,
         auth=(os.environ['GITHUB_USERNAME'], os.environ['GITHUB_TOKEN']),
@@ -135,7 +136,6 @@ def fetch_project(destination, org, repo_name, name, ref, path, ignores=None, ta
         target_path = os.path.normpath(os.path.join(destination, target, stripped_path))
         mkdirp(os.path.dirname(target_path))
 
-        print 'extracting', tar_info.name, '->', target_path
         with open(target_path, 'wb') as f:
             f.write(tgz.extractfile(tar_info).read())
 

--- a/touch-up.sh
+++ b/touch-up.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -ex
+#!/bin/bash -e
 
 DOCS_DIR=$( dirname $( find /docs -name 'build.json' | head -n1 ) )
 BUILD_JSON="${DOCS_DIR}/build.json"


### PR DESCRIPTION
First commit: adjusts what gets logged during `fetch`.  Instead of logging every file that gets extracted, just log the repo that is being fetched.

Second commit: use host volumes instead of container volumes for the docs. This makes it easier to inspect the contents of the docs, and with `--watch` it lets you make changes without restarting the container.

Also uses a host volume for the fetch code, so that changes don't require a rebuild of the image.