### PR TITLE
Dtr 1.4 release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ MAINTAINER Mary Anthony <mary@docker.com> (@moxiegirl)
 WORKDIR /src
 EXPOSE 8000
 
-RUN apt-get update && apt-get install -y gettext git libssl-dev make 	python-dev python-pip	python-setuptools	vim-tiny s3cmd && apt-get clean	&& rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+RUN apt-get update && apt-get install -y gettext git libssl-dev make python-dev python-pip	python-setuptools	vim-tiny s3cmd && apt-get clean	&& rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Required to publish the documentation.
 # The 1.4.4 version works: the current versions fail in different ways

--- a/all-projects.yml
+++ b/all-projects.yml
@@ -9,8 +9,8 @@ defaults:
 
 projects:
     - name: docs-base
-      org: moxiegirl
-      ref: fix-archive
+      org: docker
+      ref: hugo-github-linkin
       path: !!null
       target: .
 

--- a/all-projects.yml
+++ b/all-projects.yml
@@ -9,8 +9,8 @@ defaults:
 
 projects:
     - name: docs-base
-      org: docker
-      ref: hugo-github-linking
+      org: moxiegirl
+      ref: fix-archive
       path: !!null
       target: .
 


### PR DESCRIPTION
@SvenDowideit here is the release

```
"docs.docker.com": {
        "ref": "refs/heads/dtr-1.4-release",
        "repos": [
            "git@github.com:moxiegirl/docs.docker.com.git",
            "git@github.com:docker/docs.docker.com.git"
        ],
        "sha": "283171a457da3124ff93353850395354e49e578c"
    }
```