### PR TITLE
possible fix for 404 styling issue in prod

### DIFF
--- a/make.sh
+++ b/make.sh
@@ -46,8 +46,8 @@ build() {
 		DEST_PATH=""
 	fi
 
-	echo "RUNNING: hugo -d /public/$DEST_PATH --baseUrl=http://$S3HOSTNAME/$DEST_PATH --config=config.toml"
-	hugo -d /public/$DEST_PATH --baseUrl=http://$S3HOSTNAME/$DEST_PATH --config=config.toml
+	echo "RUNNING: hugo -d /public/$DEST_PATH --baseUrl=https://$S3HOSTNAME/$DEST_PATH --config=config.toml"
+	hugo -d /public/$DEST_PATH --baseUrl=https://$S3HOSTNAME/$DEST_PATH --config=config.toml
 }
 
 upload() {


### PR DESCRIPTION
make the buseUrl https

I'm guessing there's a s3/cloudfront option that makes dev&test buckets work, but this may get us there.

Signed-off-by: Sven Dowideit <SvenDowideit@home.org.au>